### PR TITLE
fix: validate JWT introspection response to check "active" flag

### DIFF
--- a/api/src/handlers/command.ts
+++ b/api/src/handlers/command.ts
@@ -87,7 +87,11 @@ const verifyCommandToken = async (command_token: string) => {
             return false
         }
         const json = await response.json()
-        return json
+        if (!json.active) {
+            console.error('commands.verifyCommandToken: token is inactive')
+            return false
+        }
+        return json        
     } catch (e) {
         console.error('error verifying command token', e)
         return false


### PR DESCRIPTION
Ensures that the OAuth 2.0 token introspection response includes "active": true. Prevents expired, revoked, or invalid tokens from being accepted.

#52